### PR TITLE
Query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "srtree",
     "demo",
+    "bench",
 ]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "demo"
+name = "bench"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,3 +7,8 @@ edition = "2021"
 
 [dependencies]
 srtree = { path = "../srtree" }
+rand = "0.8.5"
+ordered-float = "3.4.0"
+lotsa = "*"
+rtree_rs = "0.1.4"
+rstar = "0.9.3"

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,0 +1,77 @@
+use srtree::{Params, SRTree};
+
+fn test_srtree() {
+    const N: usize = 1_000_000; // # of training points
+    const D: usize = 9; // dimension of each point
+    const M: usize = 1000; // # of search points
+    const K: usize = 1; // # of nearest neighbors to search
+
+    println!();
+    println!("Number of training points:   {:?}", N);
+    println!("Dimension of each point:     {:?}", D);
+    println!("Number of query points:      {:?}", M);
+    println!("Number of nearest neighbors: {:?}", K);
+
+    let mut pts = Vec::new();
+    for _ in 0..N {
+        let mut point = [0.; D];
+        for item in point.iter_mut().take(D) {
+            *item = rand::random::<f64>() * 1_000_000.;
+        }
+        pts.push(point);
+    }
+
+    let mut search_points = Vec::new();
+    for _ in 0..M {
+        let mut point = [0.; D];
+        for item in point.iter_mut().take(D) {
+            *item = rand::random::<f64>() * 1_000_000.;
+        }
+        search_points.push(point);
+    }
+
+    println!();
+    println!("---- RTree ----");
+    let mut tree = rtree_rs::RTree::new();
+    print!("insert:        ");
+    lotsa::ops(pts.len(), 1, |i, _| {
+        tree.insert(rtree_rs::Rect::new(pts[i], pts[i]), i);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        let target = rtree_rs::Rect::new(search_points[i], search_points[i]);
+        tree.nearby(|rect, _| rect.box_dist(&target)).next();
+    });
+
+    println!();
+    println!("---- RStar ----");
+    let mut tree = rstar::RTree::new();
+    print!("insert:        ");
+    lotsa::ops(N, 1, |i, _| {
+        tree.insert(pts[i]);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        tree.nearest_neighbor_iter(&search_points[i]).next();
+    });
+
+    println!();
+    println!("---- SRTree ----");
+    let max_elements = 32;
+    let min_elements = max_elements * 20 / 100;
+    let reinsert_count = min_elements;
+    let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
+    let mut tree = SRTree::new(D, params);
+    print!("insert:        ");
+    lotsa::ops(pts.len(), 1, |i, _| {
+        tree.insert(&pts[i]);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        tree.query(&search_points[i], K);
+    });
+}
+
+fn main() {
+    test_srtree();
+}

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -3,8 +3,8 @@ use srtree::{Params, SRTree};
 fn test_srtree() {
     const N: usize = 1_000_000; // # of training points
     const D: usize = 9; // dimension of each point
-    const M: usize = 1000; // # of search points
-    const K: usize = 1; // # of nearest neighbors to search
+    const M: usize = 100; // # of search points
+    const K: usize = 100; // # of nearest neighbors to search
 
     println!();
     println!("Number of training points:   {:?}", N);
@@ -39,8 +39,16 @@ fn test_srtree() {
     });
     print!("kNN query:     ");
     lotsa::ops(search_points.len(), 1, |i, _| {
+        // scan kNN
+        let mut count = 0;
         let target = rtree_rs::Rect::new(search_points[i], search_points[i]);
-        tree.nearby(|rect, _| rect.box_dist(&target)).next();
+        while let Some(_) = tree.nearby(|rect, _| rect.box_dist(&target)).next() {
+            count += 1;
+            if count == K {
+                break;
+            }
+        }
+        assert_eq!(count, K);
     });
 
     println!();
@@ -52,7 +60,14 @@ fn test_srtree() {
     });
     print!("kNN query:     ");
     lotsa::ops(search_points.len(), 1, |i, _| {
-        tree.nearest_neighbor_iter(&search_points[i]).next();
+        let mut count = 0;
+        while let Some(_) = tree.nearest_neighbor_iter(&search_points[i]).next() {
+            count += 1;
+            if count == K {
+                break;
+            }
+        }
+        assert_eq!(count, K);
     });
 
     println!();

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 srtree = { path = "../srtree" }
+rand = "0.8.5"
+ordered-float = "3.4.0"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,45 +1,17 @@
-use ordered_float::OrderedFloat;
-use rand::prelude::*;
 use srtree::{Params, SRTree};
-
-fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
-    if point1.len() != point2.len() {
-        return f64::INFINITY;
-    }
-    let mut distance = 0.;
-    for i in 0..point1.len() {
-        distance += (point1[i] - point2[i]).powi(2);
-    }
-    distance.sqrt()
-}
 
 fn main() {
     let params = Params::new(7, 15, 7, true).unwrap();
     let mut tree: SRTree<f64> = SRTree::new(2, params);
     let number_of_points = 100;
-    let mut rng = rand::thread_rng();
 
-    let mut inserted = 0;
-    let mut all_points = Vec::new();
-    while inserted < number_of_points {
-        let x: f64 = 1000. * rng.gen::<f64>();
-        let y: f64 = 1000. * rng.gen::<f64>();
-        all_points.push(vec![x, y]);
+    for i in 0..number_of_points {
+        let x = f64::from(i);
+        let y = f64::from(i);
         tree.insert(&[x, y]);
-        inserted += 1;
     }
 
-    let mut points = all_points.clone();
-    for p in &all_points {
-        let k = 10;
-        let result = tree.query(p, 10);
-
-        // brute-force
-        points.sort_by_key(|a| OrderedFloat(euclidean(p, a)));
-
-        // compare the query result with brute-force
-        for i in 0..k {
-            assert_eq!(result[i], points[i]);
-        }
-    }
+    let neighbors = tree.query(&[0., 0.], 2);
+    println!("{:?}", neighbors[0]); // [0., 0.]
+    println!("{:?}", neighbors[1]); // [1., 1.]
 }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,6 +1,6 @@
 use ordered_float::OrderedFloat;
 use rand::prelude::*;
-use srtree::{SRTree, Params};
+use srtree::{Params, SRTree};
 
 pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
     if point1.len() != point2.len() {
@@ -15,7 +15,7 @@ pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
 
 fn main() {
     let params = Params::new(7, 15, 7, true).unwrap();
-    let mut tree: SRTree<f64> = SRTree::new(params);
+    let mut tree: SRTree<f64> = SRTree::new(2, params);
     let number_of_points = 100;
     let mut rng = rand::thread_rng();
 
@@ -33,8 +33,11 @@ fn main() {
     for p in all_points.iter() {
         let k = 10;
         let result = tree.query(&p, 10);
+
+        // brute-force
         points.sort_by_key(|a| OrderedFloat(euclidean(p, a)));
 
+        // compare the query result with brute-force
         for i in 0..k {
             assert_eq!(result[i], points[i]);
         }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -2,7 +2,7 @@ use ordered_float::OrderedFloat;
 use rand::prelude::*;
 use srtree::{Params, SRTree};
 
-pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
+fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
     if point1.len() != point2.len() {
         return f64::INFINITY;
     }
@@ -30,9 +30,9 @@ fn main() {
     }
 
     let mut points = all_points.clone();
-    for p in all_points.iter() {
+    for p in &all_points {
         let k = 10;
-        let result = tree.query(&p, 10);
+        let result = tree.query(p, 10);
 
         // brute-force
         points.sort_by_key(|a| OrderedFloat(euclidean(p, a)));

--- a/srtree/Cargo.toml
+++ b/srtree/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 ordered-float = "3.4.0"
 priority-queue = "1.3.0"
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/srtree/Cargo.toml
+++ b/srtree/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 ordered-float = "3.4.0"
-priority-queue = "1.3.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/srtree/src/algorithm/choose_subtree.rs
+++ b/srtree/src/algorithm/choose_subtree.rs
@@ -1,4 +1,4 @@
-use crate::measure::distance::euclidean;
+use crate::measure::distance::euclidean_squared;
 use crate::node::Node;
 use ordered_float::Float;
 use std::{
@@ -16,7 +16,7 @@ where
     let mut distance = T::infinity();
     for (i, child) in node.nodes().iter().enumerate() {
         let current_distance =
-            euclidean(&child.get_sphere().center, &search_node.get_sphere().center);
+            euclidean_squared(&child.get_sphere().center, &search_node.get_sphere().center);
         if current_distance < distance {
             distance = current_distance;
             closest_node_index = i;

--- a/srtree/src/algorithm/insertion.rs
+++ b/srtree/src/algorithm/insertion.rs
@@ -168,7 +168,7 @@ mod tests {
     use std::ops::Div;
 
     use super::*;
-    use crate::algorithm::{choose_subtree::choose_subtree, query::nearest_neighbors};
+    use crate::algorithm::choose_subtree::choose_subtree;
 
     #[test]
     pub fn test_leaf_insertion() {

--- a/srtree/src/algorithm/insertion.rs
+++ b/srtree/src/algorithm/insertion.rs
@@ -176,9 +176,7 @@ mod tests {
         let params = Params::new(4, 9, 4, true).unwrap();
         let mut leaf_node = Node::new_leaf(&point, params.max_number_of_elements);
         insert_data(&mut leaf_node, &point, &params);
-        let mut result = Vec::new();
-        nearest_neighbors(&mut leaf_node, &point, 1, &mut result);
-        assert!(result.contains(&point));
+        assert!(leaf_node.points().contains(&point));
     }
 
     #[test]

--- a/srtree/src/algorithm/insertion.rs
+++ b/srtree/src/algorithm/insertion.rs
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     pub fn test_leaf_insertion() {
         let point = vec![0., 0.];
-        let params = Params::new(4, 9, 4, true);
+        let params = Params::new(4, 9, 4, true).unwrap();
         let mut leaf_node = Node::new_leaf(&point, params.max_number_of_elements);
         insert_data(&mut leaf_node, &point, &params);
         let mut result = Vec::new();
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     pub fn test_insert_now() {
-        let params = Params::new(1, 10, 4, true);
+        let params = Params::new(1, 10, 4, true).unwrap();
 
         // first leaf
         let point = vec![0., 0.];
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     pub fn test_insert_overflow_treatment() {
-        let params = Params::new(1, 4, 2, true);
+        let params = Params::new(1, 4, 2, true).unwrap();
 
         // first leaf
         let point = vec![0., 0.];
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     pub fn test_insert_dynamic_reorganization() {
-        let params = Params::new(1, 4, 2, true);
+        let params = Params::new(1, 4, 2, true).unwrap();
 
         // The first leaf
         let first_leaf_points = vec![vec![1., 1.], vec![3., 1.], vec![1., 3.], vec![3., 3.]];

--- a/srtree/src/algorithm/query.rs
+++ b/srtree/src/algorithm/query.rs
@@ -1,4 +1,4 @@
-use crate::measure::distance::euclidean;
+use crate::measure::distance::euclidean_squared;
 use crate::node::Node;
 use ordered_float::{Float, OrderedFloat};
 use std::{
@@ -14,7 +14,7 @@ where
     let mut result = Vec::new();
     let mut distance_heap = BinaryHeap::new();
     search(node, point, k, &mut result, &mut distance_heap);
-    result.sort_by_key(|neighbor| OrderedFloat(euclidean(point, neighbor)));
+    result.sort_by_key(|neighbor| OrderedFloat(euclidean_squared(point, neighbor)));
     result
 }
 
@@ -30,7 +30,7 @@ fn search<T>(
     if node.is_leaf() {
         // insert all potential neighbors in a leaf node:
         node.points().iter().for_each(|neighbor| {
-            let neighbor_distance = euclidean(neighbor, point);
+            let neighbor_distance = euclidean_squared(neighbor, point);
             distance_heap.push(OrderedFloat(neighbor_distance));
             result.push(neighbor.clone());
         });

--- a/srtree/src/algorithm/query.rs
+++ b/srtree/src/algorithm/query.rs
@@ -7,11 +7,57 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-pub fn nearest_neighbors<T>(node: &Node<T>, point: &[T], k: usize, result: &mut Vec<Vec<T>>)
+fn min_distance<T>(node: &Node<T>, point: &[T]) -> T
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
-    if node.is_leaf() {
+    let ds = node.get_sphere().min_distance(point);
+    let dr = node.get_rect().min_distance(point);
+    ds.max(dr)
+}
+
+fn min_max_distance<T>(node: &Node<T>, point: &[T]) -> T
+where
+    T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
+{
+    node.get_rect().min_max_distance(point)
+}
+
+pub fn nearest_neighbors<T>(node: &Node<T>, point: &[T], k: usize, distance: T) -> (Vec<Vec<T>>, T)
+where
+    T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
+{
+    if !node.is_leaf() {
+        // construct a queue with distance as a priority
+        let mut queue: DoublePriorityQueue<usize, OrderedFloat<T>> = DoublePriorityQueue::new();
+        for (index, candidate) in node.nodes().iter().enumerate() {
+            queue.push(index, OrderedFloat(min_distance(node, point)));
+        }
+
+        let mut result = Vec::new();
+        let mut target_distance = OrderedFloat(distance);
+        let mut max_distance = T::infinity();
+        while !queue.is_empty() {
+            let (index, min_distance) = queue.pop_min().unwrap();
+
+            // downward pruning: 
+            // there are already k neighbors, no need to explore nodes with min_distance is bigger than result.max_distance
+            if min_distance > target_distance {
+                break
+            }
+
+            let (candidates, cand_max_distance) = nearest_neighbors(&node.nodes()[index], point, k, distance);
+            result.extend(candidates);
+            max_distance = max_distance.max(cand_max_distance);
+
+            if result.len() >= k {
+                target_distance = OrderedFloat(max_distance);
+            }
+        }
+
+        result.sort_by_key(|neighbor| OrderedFloat(euclidean(neighbor, point)));
+        (result, max_distance)
+    } else {
         // construct a queue with distance as a priority
         let mut queue: DoublePriorityQueue<usize, OrderedFloat<T>> = DoublePriorityQueue::new();
         for (index, candidate) in node.points().iter().enumerate() {
@@ -19,16 +65,18 @@ where
         }
 
         // keep selecting the next nearest item until k neighbors are found:
+        let mut result = Vec::new();
+        let mut max_distance = T::infinity();
         while !queue.is_empty() {
-            let (index, _) = queue.pop_min().unwrap();
+            let (index, distance) = queue.pop_min().unwrap();
             if result.len() < k {
                 result.push(node.points()[index].clone());
+                max_distance = max_distance.max(distance.0);
             } else {
                 break;
             }
         }
-    } else {
-        todo!("query from a node");
+        (result, max_distance)
     }
 }
 
@@ -50,9 +98,8 @@ mod tests {
             insert_data(&mut leaf_node, &point, &params);
         }
 
-        let mut result = Vec::new();
         let k = params.max_number_of_elements / 3;
-        nearest_neighbors(&leaf_node, &origin, k, &mut result);
+        let (result, max_distance) = nearest_neighbors(&mut leaf_node, &origin, k, f64::infinity());
 
         assert!(result.len() == k);
         for i in 0..k {

--- a/srtree/src/algorithm/query.rs
+++ b/srtree/src/algorithm/query.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     pub fn test_nearest_neighbors_with_leaf() {
-        let params = Params::new(4, 9, 4, true);
+        let params = Params::new(4, 9, 4, true).unwrap();
         let origin = vec![0., 0.];
         let mut leaf_node = Node::new_leaf(&origin, params.max_number_of_elements);
 

--- a/srtree/src/algorithm/split.rs
+++ b/srtree/src/algorithm/split.rs
@@ -1,4 +1,4 @@
-use crate::measure::distance::euclidean;
+use crate::measure::distance::euclidean_squared;
 use crate::measure::mean;
 use crate::node::Node;
 use crate::shape::reshape::reshape;
@@ -91,10 +91,10 @@ where
     let mut index = choose_split_index(node, params);
 
     let node_centroid = mean::calculate(node, 0, index);
-    let node_distance = euclidean(parent_centroid, &node_centroid);
+    let node_distance = euclidean_squared(parent_centroid, &node_centroid);
 
     let sibling_centroid = mean::calculate(node, index, node.immed_children());
-    let sibling_distance = euclidean(parent_centroid, &sibling_centroid);
+    let sibling_distance = euclidean_squared(parent_centroid, &sibling_centroid);
 
     if node_distance > sibling_distance {
         if node.is_leaf() {

--- a/srtree/src/algorithm/split.rs
+++ b/srtree/src/algorithm/split.rs
@@ -180,7 +180,7 @@ mod tests {
             node.points_mut().push(point.to_owned());
         });
 
-        let params = Params::new(2, 3, 1, true);
+        let params = Params::new(1, 3, 1, true).unwrap();
         let expected_index = 3;
         let selected_index = choose_split_index(&node, &params);
         assert_eq!(expected_index, selected_index);
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     pub fn test_split_leaf_node() {
-        let params = Params::new(2, 5, 2, true);
+        let params = Params::new(2, 5, 2, true).unwrap();
 
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, params.max_number_of_elements);
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     pub fn test_split_node() {
-        let params = Params::new(2, 5, 2, true);
+        let params = Params::new(2, 5, 2, true).unwrap();
 
         let origin = vec![0., 0.];
         let mut node = Node::new_node(&origin, params.max_number_of_elements, 1);
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     pub fn test_split_node_with_parent() {
-        let params = Params::new(2, 5, 2, true);
+        let params = Params::new(2, 5, 2, true).unwrap();
 
         let origin = vec![0., 10.];
         let mut node = Node::new_leaf(&origin, params.max_number_of_elements);

--- a/srtree/src/lib.rs
+++ b/srtree/src/lib.rs
@@ -5,3 +5,4 @@ mod params;
 mod shape;
 mod srtree;
 pub use crate::srtree::SRTree;
+pub use crate::params::Params;

--- a/srtree/src/lib.rs
+++ b/srtree/src/lib.rs
@@ -4,5 +4,6 @@ mod node;
 mod params;
 mod shape;
 mod srtree;
-pub use crate::srtree::SRTree;
 pub use crate::params::Params;
+pub use crate::srtree::InsertionResult;
+pub use crate::srtree::SRTree;

--- a/srtree/src/measure/distance.rs
+++ b/srtree/src/measure/distance.rs
@@ -8,7 +8,7 @@ pub fn euclidean<T>(point1: &[T], point2: &[T]) -> T
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
-    euclidean_squared(point1, point2) //.sqrt()
+    euclidean_squared(point1, point2).sqrt()
 }
 
 pub fn euclidean_squared<T>(point1: &[T], point2: &[T]) -> T

--- a/srtree/src/measure/distance.rs
+++ b/srtree/src/measure/distance.rs
@@ -8,6 +8,13 @@ pub fn euclidean<T>(point1: &[T], point2: &[T]) -> T
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
+    euclidean_squared(point1, point2).sqrt()
+}
+
+pub fn euclidean_squared<T>(point1: &[T], point2: &[T]) -> T
+where
+    T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
+{
     if point1.len() != point2.len() {
         return T::infinity();
     }
@@ -15,7 +22,7 @@ where
     for i in 0..point1.len() {
         distance += (point1[i] - point2[i]).powi(2);
     }
-    distance.sqrt()
+    distance
 }
 
 #[cfg(test)]

--- a/srtree/src/measure/distance.rs
+++ b/srtree/src/measure/distance.rs
@@ -8,7 +8,7 @@ pub fn euclidean<T>(point1: &[T], point2: &[T]) -> T
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
-    euclidean_squared(point1, point2).sqrt()
+    euclidean_squared(point1, point2) //.sqrt()
 }
 
 pub fn euclidean_squared<T>(point1: &[T], point2: &[T]) -> T

--- a/srtree/src/node.rs
+++ b/srtree/src/node.rs
@@ -216,10 +216,6 @@ where
             self.nodes_mut().split_off(number_of_immediate_children - n)
         }
     }
-
-    pub fn intersects_point(&self, point: &[T]) -> bool {
-        self.rect.intersects_point(point) && self.sphere.intersects_point(point)
-    }
 }
 
 #[cfg(test)]

--- a/srtree/src/node.rs
+++ b/srtree/src/node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    measure::distance::euclidean,
+    measure::distance::euclidean_squared,
     shape::{rect::Rect, sphere::Sphere},
 };
 use ordered_float::{Float, OrderedFloat};
@@ -199,7 +199,7 @@ where
         let number_of_immediate_children = self.immed_children();
         if self.is_leaf() {
             self.points_mut()
-                .sort_by_key(|p| OrderedFloat(euclidean(&center, p)));
+                .sort_by_key(|p| OrderedFloat(euclidean_squared(&center, p)));
             self.points_mut()
                 .split_off(number_of_immediate_children - n)
                 .iter()
@@ -207,7 +207,7 @@ where
                 .collect()
         } else {
             self.nodes_mut()
-                .sort_by_key(|node| OrderedFloat(euclidean(&center, &node.sphere.center)));
+                .sort_by_key(|node| OrderedFloat(euclidean_squared(&center, &node.sphere.center)));
             self.nodes_mut().split_off(number_of_immediate_children - n)
         }
     }

--- a/srtree/src/node.rs
+++ b/srtree/src/node.rs
@@ -22,7 +22,6 @@ pub struct Node<T> {
     height: usize, // height above leaf
 }
 
-#[allow(dead_code)]
 impl<T> Node<T>
 where
     T: Debug + Copy + Float + AddAssign + SubAssign + MulAssign + DivAssign,
@@ -183,10 +182,6 @@ where
         }
     }
 
-    pub fn set_height(&mut self, height: usize) {
-        self.height = height;
-    }
-
     pub fn get_height(&self) -> usize {
         self.height
     }
@@ -215,6 +210,15 @@ where
                 .sort_by_key(|node| OrderedFloat(euclidean(&center, &node.sphere.center)));
             self.nodes_mut().split_off(number_of_immediate_children - n)
         }
+    }
+
+    pub fn min_distance(&self, point: &[T]) -> T
+    where
+        T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
+    {
+        let ds = self.get_sphere().min_distance(point);
+        let dr = self.get_rect().min_distance(point);
+        ds.max(dr)
     }
 }
 

--- a/srtree/src/params.rs
+++ b/srtree/src/params.rs
@@ -6,7 +6,6 @@ pub struct Params {
 }
 
 impl Params {
-
     #[must_use]
     pub fn new(
         min_number_of_elements: usize,
@@ -14,7 +13,9 @@ impl Params {
         reinsert_count: usize,
         prefer_close_reinsert: bool,
     ) -> Option<Params> {
-        if min_number_of_elements > (max_number_of_elements + 1) / 2 || reinsert_count >= max_number_of_elements - min_number_of_elements {
+        if min_number_of_elements > (max_number_of_elements + 1) / 2
+            || reinsert_count >= max_number_of_elements - min_number_of_elements
+        {
             return None;
         }
         Some(Params {
@@ -35,7 +36,12 @@ mod tests {
         let min_num_of_elements_per_node = 6;
         let max_num_of_elements_per_node = 10;
         let reinsert_count = 4;
-        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        let params = Params::new(
+            min_num_of_elements_per_node,
+            max_num_of_elements_per_node,
+            reinsert_count,
+            true,
+        );
         assert!(params.is_none())
     }
 
@@ -44,7 +50,12 @@ mod tests {
         let min_num_of_elements_per_node = 4;
         let max_num_of_elements_per_node = 10;
         let reinsert_count = 7;
-        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        let params = Params::new(
+            min_num_of_elements_per_node,
+            max_num_of_elements_per_node,
+            reinsert_count,
+            true,
+        );
         assert!(params.is_none())
     }
 
@@ -53,7 +64,12 @@ mod tests {
         let min_num_of_elements_per_node = 4;
         let max_num_of_elements_per_node = 10;
         let reinsert_count = 5;
-        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        let params = Params::new(
+            min_num_of_elements_per_node,
+            max_num_of_elements_per_node,
+            reinsert_count,
+            true,
+        );
         assert!(params.is_some())
     }
 }

--- a/srtree/src/params.rs
+++ b/srtree/src/params.rs
@@ -6,18 +6,54 @@ pub struct Params {
 }
 
 impl Params {
+
+    #[must_use]
     pub fn new(
         min_number_of_elements: usize,
         max_number_of_elements: usize,
         reinsert_count: usize,
         prefer_close_reinsert: bool,
-    ) -> Params {
-        // todo: validate params
-        Params {
+    ) -> Option<Params> {
+        if min_number_of_elements > (max_number_of_elements + 1) / 2 || reinsert_count >= max_number_of_elements - min_number_of_elements {
+            return None;
+        }
+        Some(Params {
             min_number_of_elements,
             max_number_of_elements,
             reinsert_count,
             prefer_close_reinsert,
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_with_invalid_min_num_elements() {
+        let min_num_of_elements_per_node = 6;
+        let max_num_of_elements_per_node = 10;
+        let reinsert_count = 4;
+        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        assert!(params.is_none())
+    }
+
+    #[test]
+    pub fn test_with_invalid_reinsert_count() {
+        let min_num_of_elements_per_node = 4;
+        let max_num_of_elements_per_node = 10;
+        let reinsert_count = 7;
+        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        assert!(params.is_none())
+    }
+
+    #[test]
+    pub fn test_with_valid_params() {
+        let min_num_of_elements_per_node = 4;
+        let max_num_of_elements_per_node = 10;
+        let reinsert_count = 5;
+        let params = Params::new(min_num_of_elements_per_node, max_num_of_elements_per_node, reinsert_count, true);
+        assert!(params.is_some())
     }
 }

--- a/srtree/src/shape/rect.rs
+++ b/srtree/src/shape/rect.rs
@@ -1,4 +1,4 @@
-use crate::measure::distance::euclidean;
+use crate::measure::distance::euclidean_squared;
 use ordered_float::Float;
 use std::{
     fmt::Debug,
@@ -34,7 +34,7 @@ where
                 closest_point[i] = point[i];
             }
         }
-        euclidean(&closest_point, point)
+        euclidean_squared(&closest_point, point)
     }
 
     pub fn farthest_point_to(&self, point: &[T]) -> Vec<T> {
@@ -52,7 +52,7 @@ where
     #[allow(dead_code)]
     pub fn min_max_distance(&self, point: &[T]) -> T {
         let min_max = self.farthest_point_to(point);
-        let mut distance = euclidean(&min_max, point);
+        let mut distance = euclidean_squared(&min_max, point);
         for i in 0..self.low.len() {
             let mut current = min_max.clone();
             if current[i] == self.low[i] {
@@ -60,7 +60,7 @@ where
             } else {
                 current[i] = self.low[i];
             }
-            let current_distance = euclidean(&current, point);
+            let current_distance = euclidean_squared(&current, point);
             if current_distance < distance {
                 distance = current_distance;
             }
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     pub fn test_rect_min_distance() {
         let rec = Rect::new(vec![5., 5.], vec![10., 10.]);
-        assert_eq!(rec.min_distance(&vec![5., 0.]), 5.);
+        assert_eq!(rec.min_distance(&vec![5., 0.]), 25.);
     }
 
     #[test]
@@ -92,6 +92,6 @@ mod tests {
     #[test]
     pub fn test_rect_min_max_distance() {
         let rec = Rect::new(vec![5., 5.], vec![10., 10.]);
-        assert_eq!(rec.min_max_distance(&vec![15., 5.]), (50.).sqrt());
+        assert_eq!(rec.min_max_distance(&vec![15., 5.]), 50.);
     }
 }

--- a/srtree/src/shape/rect.rs
+++ b/srtree/src/shape/rect.rs
@@ -11,7 +11,6 @@ pub struct Rect<T> {
     pub high: Vec<T>,
 }
 
-#[allow(dead_code)]
 impl<T> Rect<T>
 where
     T: Debug + Copy + Float + AddAssign + SubAssign + MulAssign + DivAssign,
@@ -50,6 +49,7 @@ where
         result
     }
 
+    #[allow(dead_code)]
     pub fn min_max_distance(&self, point: &[T]) -> T {
         let min_max = self.farthest_point_to(point);
         let mut distance = euclidean(&min_max, point);

--- a/srtree/src/shape/sphere.rs
+++ b/srtree/src/shape/sphere.rs
@@ -5,14 +5,12 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Sphere<T> {
     pub center: Vec<T>,
     pub radius: T,
 }
 
-#[allow(dead_code)]
 impl<T> Sphere<T>
 where
     T: Debug + Copy + Float + AddAssign + SubAssign + MulAssign + DivAssign,

--- a/srtree/src/shape/sphere.rs
+++ b/srtree/src/shape/sphere.rs
@@ -25,7 +25,7 @@ where
 
     pub fn min_distance(&self, point: &[T]) -> T {
         let distance = euclidean(&self.center, point);
-        T::zero().max(distance - (self.radius))
+        T::zero().max(distance - (self.radius)).powi(2)
     }
 }
 
@@ -37,6 +37,6 @@ mod tests {
     pub fn test_sphere_min_distance() {
         let sphere1 = Sphere::new(vec![0., 0.], 10.);
         let point1 = vec![15., 0.];
-        assert_eq!(sphere1.min_distance(&point1), 5.);
+        assert_eq!(sphere1.min_distance(&point1), 25.);
     }
 }

--- a/srtree/src/shape/sphere.rs
+++ b/srtree/src/shape/sphere.rs
@@ -25,17 +25,9 @@ where
         Sphere::new(point.to_owned(), T::zero())
     }
 
-    pub fn distance2(&self, point: &[T]) -> T {
+    pub fn min_distance(&self, point: &[T]) -> T {
         let distance = euclidean(&self.center, point);
         T::zero().max(distance - (self.radius))
-    }
-
-    pub fn intersects_point(&self, point: &[T]) -> bool {
-        self.distance2(point) <= T::zero()
-    }
-
-    pub fn intersects(&self, sphere: &Sphere<T>) -> bool {
-        self.distance2(&sphere.center) - (self.radius + sphere.radius) <= T::zero()
     }
 }
 
@@ -44,44 +36,9 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_sphere_intersects_point() {
+    pub fn test_sphere_min_distance() {
         let sphere1 = Sphere::new(vec![0., 0.], 10.);
-        let point1 = vec![5., 5.];
-        assert!(sphere1.intersects_point(&point1));
-    }
-
-    #[test]
-    pub fn test_sphere_doesnot_intersect_point() {
-        let sphere1 = Sphere::new(vec![0., 0.], 10.);
-        let point2 = vec![15., 15.];
-        assert!(!sphere1.intersects_point(&point2));
-    }
-
-    #[test]
-    pub fn test_sphere_intersects_sphere() {
-        let sphere1 = Sphere::new(vec![0., 0.], 10.);
-        let sphere2 = Sphere::new(vec![15., 15.], 15.);
-        assert!(sphere1.intersects(&sphere2));
-    }
-
-    #[test]
-    pub fn test_sphere_doesnot_intersect_sphere() {
-        let sphere1 = Sphere::new(vec![0., 0.], 5.);
-        let sphere2 = Sphere::new(vec![20., 20.], 5.);
-        assert_eq!(sphere1.intersects(&sphere2), false);
-    }
-
-    #[test]
-    pub fn test_sphere_intersects_its_clone() {
-        let sphere1 = Sphere::new(vec![0., 0.], 10.);
-        let sphere2 = Sphere::new(vec![0., 0.], 10.);
-        assert!(sphere1.intersects(&sphere2));
-    }
-
-    #[test]
-    pub fn test_sphere_intersects_smaller_sphere() {
-        let sphere1 = Sphere::new(vec![0., 0.], 10.);
-        let sphere2 = Sphere::new(vec![10., 10.], 100.);
-        assert!(sphere1.intersects(&sphere2));
+        let point1 = vec![15., 0.];
+        assert_eq!(sphere1.min_distance(&point1), 5.);
     }
 }

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -1,10 +1,9 @@
 use crate::algorithm::insertion::{insert_data, insert_node};
 use crate::algorithm::query::nearest_neighbors;
 use crate::algorithm::split::split;
-use crate::measure::distance::euclidean;
 use crate::node::Node;
 use crate::params::Params;
-use ordered_float::{Float, OrderedFloat};
+use ordered_float::Float;
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
@@ -19,7 +18,6 @@ pub struct SRTree<T> {
     params: Params,
 }
 
-#[allow(dead_code)]
 impl<T> SRTree<T>
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
@@ -62,21 +60,12 @@ where
         InsertionResult::Success
     }
 
-    pub fn query_all(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
+    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
         if let Some(root) = self.root.as_mut() {
-            let (candidates, _) = nearest_neighbors(root, point, k, T::infinity());
-            let mut result = candidates.to_owned();
-            result.sort_by_key(|candidate| OrderedFloat(euclidean(&point, &candidate)));
-            result
+            nearest_neighbors(root, point, k)
         } else {
             Vec::new()
         }
-    }
-    
-    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
-        let mut result = self.query_all(point, k);
-        result.truncate(k);
-        result
     }
 }
 

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -61,12 +61,13 @@ where
         InsertionResult::Success
     }
 
-    pub fn query(&self, point: &[T], k: usize) -> Vec<Vec<T>> {
-        let mut neighbors = Vec::with_capacity(k);
-        if let Some(root) = &self.root {
-            nearest_neighbors(root, point, k, &mut neighbors);
+    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
+        if let Some(root) = self.root.as_mut() {
+            let (result, max_distance) = nearest_neighbors(root, point, k, T::infinity());
+            result
+        } else {
+            Vec::new()
         }
-        neighbors
     }
 }
 

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -19,19 +19,11 @@ where
 {
     #[must_use]
     pub fn new(
-        min_number_of_elements: usize,
-        max_number_of_elements: usize,
-        reinsert_count: usize,
-        prefer_close_reinsert: bool,
+        params: Params
     ) -> SRTree<T> {
         SRTree {
             root: None,
-            params: Params::new(
-                min_number_of_elements,
-                max_number_of_elements,
-                reinsert_count,
-                prefer_close_reinsert,
-            ),
+            params,
         }
     }
 
@@ -74,7 +66,8 @@ mod tests {
 
     #[test]
     pub fn test_insertion_query() {
-        let mut tree: SRTree<f64> = SRTree::new(3, 10, 3, true);
+        let params = Params::new(3, 7, 3, true).unwrap();
+        let mut tree: SRTree<f64> = SRTree::new(params);
         let search_point = vec![1.0, 0.0];
         assert!(!tree.query(&search_point, 1).contains(&search_point)); // not inserted yet
         tree.insert(&vec![1.0, 0.0]);

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -7,7 +7,13 @@ use ordered_float::Float;
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
+pub enum InsertionResult {
+    Success,
+    Failure,
+}
+
 pub struct SRTree<T> {
+    dimension: usize,
     root: Option<Node<T>>,
     params: Params,
 }
@@ -18,16 +24,19 @@ where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
     #[must_use]
-    pub fn new(
-        params: Params
-    ) -> SRTree<T> {
+    pub fn new(dimension: usize, params: Params) -> SRTree<T> {
         SRTree {
             root: None,
             params,
+            dimension,
         }
     }
 
-    pub fn insert(&mut self, point: &[T]) {
+    pub fn insert(&mut self, point: &[T]) -> InsertionResult {
+        if self.dimension != point.len() {
+            eprintln!("Problem inserting a point: different dimensions");
+            return InsertionResult::Failure;
+        }
         if self.root.is_none() {
             self.root = Some(Node::new_leaf(point, self.params.max_number_of_elements));
         }
@@ -49,6 +58,7 @@ where
                 self.root = Some(new_root);
             }
         }
+        InsertionResult::Success
     }
 
     pub fn query(&self, point: &[T], k: usize) -> Vec<Vec<T>> {
@@ -67,7 +77,7 @@ mod tests {
     #[test]
     pub fn test_insertion_query() {
         let params = Params::new(3, 7, 3, true).unwrap();
-        let mut tree: SRTree<f64> = SRTree::new(params);
+        let mut tree: SRTree<f64> = SRTree::new(2, params);
         let search_point = vec![1.0, 0.0];
         assert!(!tree.query(&search_point, 1).contains(&search_point)); // not inserted yet
         tree.insert(&vec![1.0, 0.0]);

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -1,9 +1,10 @@
 use crate::algorithm::insertion::{insert_data, insert_node};
 use crate::algorithm::query::nearest_neighbors;
 use crate::algorithm::split::split;
+use crate::measure::distance::euclidean;
 use crate::node::Node;
 use crate::params::Params;
-use ordered_float::Float;
+use ordered_float::{Float, OrderedFloat};
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
@@ -61,13 +62,21 @@ where
         InsertionResult::Success
     }
 
-    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
+    pub fn query_all(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
         if let Some(root) = self.root.as_mut() {
-            let (result, max_distance) = nearest_neighbors(root, point, k, T::infinity());
+            let (candidates, _) = nearest_neighbors(root, point, k, T::infinity());
+            let mut result = candidates.to_owned();
+            result.sort_by_key(|candidate| OrderedFloat(euclidean(&point, &candidate)));
             result
         } else {
             Vec::new()
         }
+    }
+    
+    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
+        let mut result = self.query_all(point, k);
+        result.truncate(k);
+        result
     }
 }
 

--- a/srtree/tests/test_insertion.rs
+++ b/srtree/tests/test_insertion.rs
@@ -1,0 +1,10 @@
+use srtree::{SRTree, Params};
+
+#[test]
+#[should_panic]
+pub fn test_invalid_dimensions() {
+    let params = Params::new(3, 7, 3,true).unwrap();
+    let mut tree = SRTree::new(params);
+    tree.insert(&[0., 1.]);  // 2D insertion 
+    tree.insert(&[0., 1., 2.]); // now 3D insertion should fail
+}

--- a/srtree/tests/test_insertion.rs
+++ b/srtree/tests/test_insertion.rs
@@ -1,10 +1,13 @@
-use srtree::{SRTree, Params};
+use srtree::{InsertionResult, Params, SRTree};
 
 #[test]
-#[should_panic]
-pub fn test_invalid_dimensions() {
-    let params = Params::new(3, 7, 3,true).unwrap();
-    let mut tree = SRTree::new(params);
-    tree.insert(&[0., 1.]);  // 2D insertion 
-    tree.insert(&[0., 1., 2.]); // now 3D insertion should fail
+pub fn test_insertion_invalid_dimensions() {
+    let params = Params::new(3, 7, 3, true).unwrap();
+    let mut tree = SRTree::new(2, params);
+
+    let result = tree.insert(&[0., 1.]); // valid insertion
+    assert!(matches!(result, InsertionResult::Success));
+
+    let result = tree.insert(&[0., 1., 2.]); // now 3D insertion should fail
+    assert!(matches!(result, InsertionResult::Failure));
 }

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -37,7 +37,6 @@ fn test_with_random_points() {
 
     let mut points = all_points.clone();
     for p in all_points.iter() {
-
         // SRTree nearest neighbors
         let result = tree.query(&p, k);
 

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -15,25 +15,33 @@ pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
 
 #[test]
 fn test_with_random_points() {
-    let params = Params::new(7, 15, 7, true).unwrap();
-    let mut tree: SRTree<f64> = SRTree::new(2, params);
+    let number_of_dimensions = 2;
     let number_of_points = 100;
+    let k = 5;
+
+    let params = Params::new(3, 7, 3, true).unwrap();
+    let mut tree: SRTree<f64> = SRTree::new(number_of_dimensions, params);
+
     let mut rng = rand::thread_rng();
 
-    let mut inserted = 0;
     let mut all_points = Vec::new();
-    while inserted < number_of_points {
-        let x: f64 = 1000. * rng.gen::<f64>();
-        let y: f64 = 1000. * rng.gen::<f64>();
-        all_points.push(vec![x, y]);
-        tree.insert(&[x, y]);
-        inserted += 1;
+    for _ in 0..number_of_points {
+        let mut point = Vec::new();
+        for _ in 0..number_of_dimensions {
+            let x: f64 = 100000. * rng.gen::<f64>();
+            point.push(x);
+        }
+        tree.insert(&point);
+        all_points.push(point);
     }
 
     let mut points = all_points.clone();
     for p in all_points.iter() {
-        let k = 10;
-        let result = tree.query(&p, 10);
+
+        // SRTree nearest neighbors
+        let result = tree.query(&p, k);
+
+        // Brute-force
         points.sort_by_key(|a| OrderedFloat(euclidean(p, a)));
 
         for i in 0..k {

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -1,6 +1,6 @@
 use ordered_float::OrderedFloat;
 use rand::prelude::*;
-use srtree::{SRTree, Params};
+use srtree::{Params, SRTree};
 
 pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
     if point1.len() != point2.len() {
@@ -14,9 +14,9 @@ pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
 }
 
 #[test]
-fn test_with_random_points() {    
-    let params = Params::new(7, 15, 7,true).unwrap();
-    let mut tree: SRTree<f64> = SRTree::new(params);
+fn test_with_random_points() {
+    let params = Params::new(7, 15, 7, true).unwrap();
+    let mut tree: SRTree<f64> = SRTree::new(2, params);
     let number_of_points = 100;
     let mut rng = rand::thread_rng();
 

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -2,7 +2,7 @@ use ordered_float::OrderedFloat;
 use rand::prelude::*;
 use srtree::{Params, SRTree};
 
-pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
+pub fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
     if point1.len() != point2.len() {
         return f64::INFINITY;
     }
@@ -10,14 +10,14 @@ pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
     for i in 0..point1.len() {
         distance += (point1[i] - point2[i]).powi(2);
     }
-    distance.sqrt()
+    distance
 }
 
 #[test]
 fn test_with_random_points() {
     let number_of_dimensions = 2;
     let number_of_points = 100;
-    let k = 5;
+    let k = 10;
 
     let params = Params::new(3, 7, 3, true).unwrap();
     let mut tree: SRTree<f64> = SRTree::new(number_of_dimensions, params);
@@ -28,7 +28,7 @@ fn test_with_random_points() {
     for _ in 0..number_of_points {
         let mut point = Vec::new();
         for _ in 0..number_of_dimensions {
-            let x: f64 = 100000. * rng.gen::<f64>();
+            let x: f64 = 1000000. * rng.gen::<f64>();
             point.push(x);
         }
         tree.insert(&point);
@@ -41,7 +41,7 @@ fn test_with_random_points() {
         let result = tree.query(&p, k);
 
         // Brute-force
-        points.sort_by_key(|a| OrderedFloat(euclidean(p, a)));
+        points.sort_by_key(|a| OrderedFloat(euclidean_squared(a, p)));
 
         for i in 0..k {
             assert_eq!(result[i], points[i]);

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -13,8 +13,9 @@ pub fn euclidean(point1: &[f64], point2: &[f64]) -> f64 {
     distance.sqrt()
 }
 
-fn main() {
-    let params = Params::new(7, 15, 7, true).unwrap();
+#[test]
+fn test_with_random_points() {    
+    let params = Params::new(7, 15, 7,true).unwrap();
     let mut tree: SRTree<f64> = SRTree::new(params);
     let number_of_points = 100;
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
This PR includes these changes:
- Verifies `SRTree::Params` and prevents the insertion of points with different dimensions
- Adds integration tests for `insertion` and `query`.
- Implements an enhanced version of nearest neighbor queries (its theory from [here](https://dl.acm.org/doi/pdf/10.1145/290593.290596))
- Adds `bench` binary application to compare kNN queries with [RTree](https://github.com/tidwall/rtree.rs) and [RStar](https://github.com/georust/rstar) trees. 

The benchmarking results (on MBP 14):
```
Number of training points:   1000000
Dimension of each point:     9
Number of query points:      100
Number of nearest neighbors: 100

---- RTree ----
insert:        1,000,000 ops in 620ms, 1,610,872/sec, 620 ns/op
kNN query:     100 ops in 21120ms, 4/sec, 211203364 ns/op

---- RStar ----
insert:        1,000,000 ops in 3396ms, 294,383/sec, 3396 ns/op
kNN query:     100 ops in 13428ms, 7/sec, 134280721 ns/op

---- SRTree ----
insert:        1,000,000 ops in 23567ms, 42,431/sec, 23567 ns/op
kNN query:     100 ops in 5232ms, 19/sec, 52324377 ns/op
```