### PR TITLE
Benchmark on non-uniform dataset

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -13,7 +13,86 @@ pub fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
     distance
 }
 
-fn test_srtree() {
+fn bench_exhaustive<const D: usize>(pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
+    println!();
+    println!("---- Exhaustive search ----");
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        // iterate through the points and keep the closest K distances:
+        let mut result_heap = BinaryHeap::new();
+        pts.iter().for_each(|point| {
+            result_heap.push(OrderedFloat(euclidean_squared(&search_points[i], point)));
+            if result_heap.len() > k {
+                result_heap.pop();
+            }
+        });
+    });
+}
+
+fn bench_rtree<const D: usize>(pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
+    println!();
+    println!("---- RTree ----");
+    let mut tree = rtree_rs::RTree::new();
+    print!("insert:        ");
+    lotsa::ops(pts.len(), 1, |i, _| {
+        tree.insert(rtree_rs::Rect::new(pts[i], pts[i]), i);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        // scan kNN
+        let mut count = 0;
+        let target = rtree_rs::Rect::new(search_points[i], search_points[i]);
+        while let Some(_) = tree.nearby(|rect, _| rect.box_dist(&target)).next() {
+            count += 1;
+            if count == k {
+                break;
+            }
+        }
+        assert_eq!(count, k);
+    });
+}
+
+// Rstar supports max 9 dimensions by default
+fn bench_rstar(pts: &Vec<[f64; 9]>, search_points: &Vec<[f64; 9]>, k: usize) {
+    println!();
+    println!("---- RStar ----");
+    let mut tree = rstar::RTree::new();
+    print!("insert:        ");
+    lotsa::ops(pts.len(), 1, |i, _| {
+        tree.insert(pts[i]);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        let mut count = 0;
+        while let Some(_) = tree.nearest_neighbor_iter(&search_points[i]).next() {
+            count += 1;
+            if count == k {
+                break;
+            }
+        }
+        assert_eq!(count, k);
+    });
+}
+
+fn bench_srtree<const D: usize>(dimension: usize, pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
+    println!();
+    println!("---- SRTree ----");
+    let max_elements = 21;
+    let min_elements = 10;
+    let reinsert_count = min_elements;
+    let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
+    let mut tree = SRTree::new(dimension, params);
+    print!("insert:        ");
+    lotsa::ops(pts.len(), 1, |i, _| {
+        tree.insert(&pts[i]);
+    });
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        tree.query(&search_points[i], k);
+    });
+}
+
+fn test_with_random_dataset() {
     const N: usize = 1_000_000; // # of training points
     const D: usize = 9; // dimension of each point
     const M: usize = 100; // # of search points
@@ -43,77 +122,55 @@ fn test_srtree() {
         search_points.push(point);
     }
 
+    bench_rtree(&pts, &search_points, K);
+    bench_rstar(&pts, &search_points, K);
+    bench_srtree(D, &pts, &search_points, K);
+    bench_exhaustive(&pts, &search_points, K);
+}
+
+fn test_with_cluster_dataset(){
+    // As the dimensionality increases, points tend to form similar distances in randomly-generated datasets.
+    // Therefore, high dimensions should be benchmarked with non-uniform data (the cluster dataset):
+    const N: usize = 1000; // # of clusters
+    const W: usize = 1000; // # of points in a cluster
+    const D: usize = 100; // dimension of each point
+    const M: usize = 100; // # of search points
+    const K: usize = 100; // # of nearest neighbors to search
+
     println!();
-    println!("---- RTree ----");
-    let mut tree = rtree_rs::RTree::new();
-    print!("insert:        ");
-    lotsa::ops(pts.len(), 1, |i, _| {
-        tree.insert(rtree_rs::Rect::new(pts[i], pts[i]), i);
-    });
-    print!("kNN query:     ");
-    lotsa::ops(search_points.len(), 1, |i, _| {
-        // scan kNN
-        let mut count = 0;
-        let target = rtree_rs::Rect::new(search_points[i], search_points[i]);
-        while let Some(_) = tree.nearby(|rect, _| rect.box_dist(&target)).next() {
-            count += 1;
-            if count == K {
-                break;
+    println!("Number of clusters:   {:?}", N);
+    println!("Number of points per cluster:   {:?}", W);
+    println!("Dimension of each point:     {:?}", D);
+    println!("Number of query points:      {:?}", M);
+    println!("Number of nearest neighbors: {:?}", K);
+
+    let mut pts = Vec::new();
+    for n in 0..N {
+        let start = 10_000. * n as f64;
+        for _ in 0..W {
+            let mut point = [0.; D];
+            for item in point.iter_mut().take(D) {
+                *item = start + rand::random::<f64>() * 8000.;
             }
+            pts.push(point);
         }
-        assert_eq!(count, K);
-    });
+    }
 
-    println!();
-    println!("---- RStar ----");
-    let mut tree = rstar::RTree::new();
-    print!("insert:        ");
-    lotsa::ops(N, 1, |i, _| {
-        tree.insert(pts[i]);
-    });
-    print!("kNN query:     ");
-    lotsa::ops(search_points.len(), 1, |i, _| {
-        let mut count = 0;
-        while let Some(_) = tree.nearest_neighbor_iter(&search_points[i]).next() {
-            count += 1;
-            if count == K {
-                break;
-            }
+    let mut search_points = Vec::new();
+    for _ in 0..M {
+        let mut point = [0.; D];
+        for item in point.iter_mut().take(D) {
+            *item = rand::random::<f64>() * 2_000_000.;
         }
-        assert_eq!(count, K);
-    });
+        search_points.push(point);
+    }
 
-    println!();
-    println!("---- SRTree ----");
-    let max_elements = 32;
-    let min_elements = max_elements * 20 / 100;
-    let reinsert_count = min_elements;
-    let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
-    let mut tree = SRTree::new(D, params);
-    print!("insert:        ");
-    lotsa::ops(pts.len(), 1, |i, _| {
-        tree.insert(&pts[i]);
-    });
-    print!("kNN query:     ");
-    lotsa::ops(search_points.len(), 1, |i, _| {
-        tree.query(&search_points[i], K);
-    });
-
-    println!();
-    println!("---- Exhaustive search ----");
-    print!("kNN query:     ");
-    lotsa::ops(search_points.len(), 1, |i, _| {
-        // keep the closest K distances:
-        let mut result_heap = BinaryHeap::new();
-        pts.iter().for_each(|point| {
-            result_heap.push(OrderedFloat(euclidean_squared(&search_points[i], point)));
-            if result_heap.len() > K {
-                result_heap.pop();
-            }
-        });
-    });
+    bench_rtree(&pts, &search_points, K);
+    bench_srtree(D, &pts, &search_points, K);
+    bench_exhaustive(&pts, &search_points, K);
 }
 
 fn main() {
-    test_srtree();
+    // test_with_random_dataset();
+    test_with_cluster_dataset();
 }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,4 +1,17 @@
+use std::collections::BinaryHeap;
+use ordered_float::OrderedFloat;
 use srtree::{Params, SRTree};
+
+pub fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
+    if point1.len() != point2.len() {
+        return f64::INFINITY;
+    }
+    let mut distance = 0.;
+    for i in 0..point1.len() {
+        distance += (point1[i] - point2[i]).powi(2);
+    }
+    distance
+}
 
 fn test_srtree() {
     const N: usize = 1_000_000; // # of training points
@@ -84,6 +97,20 @@ fn test_srtree() {
     print!("kNN query:     ");
     lotsa::ops(search_points.len(), 1, |i, _| {
         tree.query(&search_points[i], K);
+    });
+
+    println!();
+    println!("---- Exhaustive search ----");
+    print!("kNN query:     ");
+    lotsa::ops(search_points.len(), 1, |i, _| {
+        // keep the closest K distances:
+        let mut result_heap = BinaryHeap::new();
+        pts.iter().for_each(|point| {
+            result_heap.push(OrderedFloat(euclidean_squared(&search_points[i], point)));
+            if result_heap.len() > K {
+                result_heap.pop();
+            }
+        });
     });
 }
 

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,8 +1,8 @@
-use std::collections::BinaryHeap;
 use ordered_float::OrderedFloat;
 use srtree::{Params, SRTree};
+use std::collections::BinaryHeap;
 
-pub fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
+fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
     if point1.len() != point2.len() {
         return f64::INFINITY;
     }
@@ -13,19 +13,19 @@ pub fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
     distance
 }
 
-fn bench_exhaustive<const D: usize>(pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
+fn bench_exhaustive<const D: usize>(pts: &[[f64; D]], search_points: &[[f64; D]], k: usize) {
     println!();
     println!("---- Exhaustive search ----");
     print!("kNN query:     ");
     lotsa::ops(search_points.len(), 1, |i, _| {
         // iterate through the points and keep the closest K distances:
         let mut result_heap = BinaryHeap::new();
-        pts.iter().for_each(|point| {
+        for point in pts.iter() {
             result_heap.push(OrderedFloat(euclidean_squared(&search_points[i], point)));
             if result_heap.len() > k {
                 result_heap.pop();
             }
-        });
+        }
     });
 }
 
@@ -74,7 +74,12 @@ fn bench_rstar(pts: &Vec<[f64; 9]>, search_points: &Vec<[f64; 9]>, k: usize) {
     });
 }
 
-fn bench_srtree<const D: usize>(dimension: usize, pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
+fn bench_srtree<const D: usize>(
+    dimension: usize,
+    pts: &Vec<[f64; D]>,
+    search_points: &Vec<[f64; D]>,
+    k: usize,
+) {
     println!();
     println!("---- SRTree ----");
     let max_elements = 21;
@@ -128,7 +133,7 @@ fn test_with_random_dataset() {
     bench_exhaustive(&pts, &search_points, K);
 }
 
-fn test_with_cluster_dataset(){
+fn test_with_cluster_dataset() {
     // As the dimensionality increases, points tend to form similar distances in randomly-generated datasets.
     // Therefore, high dimensions should be benchmarked with non-uniform data (the cluster dataset):
     const N: usize = 1000; // # of clusters
@@ -145,8 +150,8 @@ fn test_with_cluster_dataset(){
     println!("Number of nearest neighbors: {:?}", K);
 
     let mut pts = Vec::new();
-    for n in 0..N {
-        let start = 10_000. * n as f64;
+    let mut start = 0.;
+    for _ in 0..N {
         for _ in 0..W {
             let mut point = [0.; D];
             for item in point.iter_mut().take(D) {
@@ -154,6 +159,7 @@ fn test_with_cluster_dataset(){
             }
             pts.push(point);
         }
+        start += 10_000.;
     }
 
     let mut search_points = Vec::new();
@@ -171,6 +177,6 @@ fn test_with_cluster_dataset(){
 }
 
 fn main() {
-    // test_with_random_dataset();
+    test_with_random_dataset();
     test_with_cluster_dataset();
 }

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -166,7 +166,7 @@ fn test_with_cluster_dataset() {
     for _ in 0..M {
         let mut point = [0.; D];
         for item in point.iter_mut().take(D) {
-            *item = rand::random::<f64>() * 2_000_000.;
+            *item = rand::random::<f64>() * 1_000_000.;
         }
         search_points.push(point);
     }


### PR DESCRIPTION
This PR includes these changes:
- fixes a bug in `query`: the closest nodes are visited first, so that far nodes are more eligible to be pruned later.
- adds benchmarks for non-uniform dataset (cluster dataset) at 100 dimensions.
Here are the results for the uniform dataset and the cluster dataset:

```
Number of training points:   1000000
Dimension of each point:     9
Number of query points:      100
Number of nearest neighbors: 100

---- RTree ----
insert:        1,000,000 ops in 600ms, 1,664,269/sec, 600 ns/op
kNN query:     100 ops in 38688ms, 2/sec, 386883115 ns/op

---- RStar ----
insert:        1,000,000 ops in 3438ms, 290,836/sec, 3438 ns/op
kNN query:     100 ops in 9191ms, 10/sec, 91914859 ns/op

---- SRTree ----
insert:        1,000,000 ops in 23077ms, 43,331/sec, 23077 ns/op
kNN query:     100 ops in 2983ms, 33/sec, 29836849 ns/op

---- Exhaustive search ----
kNN query:     100 ops in 4240ms, 23/sec, 42408607 ns/op
```

```
Number of clusters:   1000
Number of points per cluster:   1000
Dimension of each point:     100
Number of query points:      100
Number of nearest neighbors: 100

---- RTree ----
insert:        1,000,000 ops in 15182ms, 65,866/sec, 15182 ns/op
kNN query:     100 ops in 15838ms, 6/sec, 158388726 ns/op

---- SRTree ----
insert:        1,000,000 ops in 124895ms, 8,006/sec, 124895 ns/op
kNN query:     100 ops in 1746ms, 57/sec, 17464040 ns/op

---- Exhaustive search ----
kNN query:     100 ops in 6857ms, 14/sec, 68571233 ns/op
```