### PR TITLE
Benchmarks with criterion

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 srtree = { path = "../srtree" }
 rand = "0.8.5"
 criterion = "0.3"
+rtree_rs = "0.1.4"
+rstar = "0.9.3"
 
 [[bench]]
 name = "srtree"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,6 +9,8 @@ rand = "0.8.5"
 criterion = "0.3"
 rtree_rs = "0.1.4"
 rstar = "0.9.3"
+petal-neighbors = "0.8.0"
+ndarray = "0.15"
 
 [[bench]]
 name = "srtree"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -3,8 +3,6 @@ name = "bench"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 srtree = { path = "../srtree" }
 rand = "0.8.5"
@@ -12,3 +10,8 @@ ordered-float = "3.4.0"
 lotsa = "*"
 rtree_rs = "0.1.4"
 rstar = "0.9.3"
+criterion = "0.3"
+
+[[bench]]
+name = "srtree"
+harness = false

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -3,16 +3,14 @@ name = "bench"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-ordered-float = "3.4.0"
+[dev-dependencies]
 srtree = { path = "../srtree" }
 rand = "0.8.5"
 rtree_rs = "0.1.4"
 rstar = "0.9.3"
 petal-neighbors = "0.8.0"
 ndarray = "0.15"
-
-[dev-dependencies]
+ordered-float = "3.4.0"
 criterion = "0.3"
 
 [[bench]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ordered-float = "3.4.0"
 srtree = { path = "../srtree" }
 rand = "0.8.5"
 criterion = "0.3"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 [dependencies]
 srtree = { path = "../srtree" }
 rand = "0.8.5"
-ordered-float = "3.4.0"
-lotsa = "*"
-rtree_rs = "0.1.4"
-rstar = "0.9.3"
 criterion = "0.3"
 
 [[bench]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 ordered-float = "3.4.0"
 srtree = { path = "../srtree" }
 rand = "0.8.5"
-criterion = "0.3"
 rtree_rs = "0.1.4"
 rstar = "0.9.3"
 petal-neighbors = "0.8.0"
 ndarray = "0.15"
+
+[dev-dependencies]
+criterion = "0.3"
 
 [[bench]]
 name = "srtree"

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -80,9 +80,7 @@ fn query(criterion: &mut Criterion) {
                 }
             }
         });
-    });
-
-    group.bench_function("rstar", |bencher| {
+    }).bench_function("rstar", |bencher| {
         bencher.iter(|| {
             for i in 0..M {
                 let mut count = 0;
@@ -94,9 +92,7 @@ fn query(criterion: &mut Criterion) {
                 }
             }
         });
-    });
-
-    group.bench_function("srtree", |bencher| {
+    }).bench_function("srtree", |bencher| {
         bencher.iter(|| {
             for point in &query_pts {
                 srtree.query(point, K);

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -1,203 +1,69 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ordered_float::OrderedFloat;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{rngs::StdRng, SeedableRng, Rng};
 use srtree::{Params, SRTree};
-use std::{collections::BinaryHeap, time::Duration};
 
-fn euclidean_squared(point1: &[f64], point2: &[f64]) -> f64 {
-    if point1.len() != point2.len() {
-        return f64::INFINITY;
-    }
-    let mut distance = 0.;
-    for i in 0..point1.len() {
-        distance += (point1[i] - point2[i]).powi(2);
-    }
-    distance
-}
+const INPUT_SEED: [u8; 32] = *b"PiH6Xi3GBBXhTK6UsXJYngHaF3fx4aYS";
+const QUERY_SEED: [u8; 32] = *b"H4NNoe0r5BDtWChfJEgXpXCNaS5IfVxC";
 
-fn bench_exhaustive<const D: usize>(pts: &[[f64; D]], search_points: &[[f64; D]], k: usize) {
-    for search_point in search_points {
-        // iterate through the points and keep the closest K distances:
-        let mut result_heap = BinaryHeap::new();
-        for point in pts.iter() {
-            result_heap.push(OrderedFloat(euclidean_squared(search_point, point)));
-            if result_heap.len() > k {
-                result_heap.pop();
-            }
-        }
-    }
-}
-
-fn bench_rtree<const D: usize>(pts: &Vec<[f64; D]>, search_points: &Vec<[f64; D]>, k: usize) {
-    let mut tree = rtree_rs::RTree::new();
-    for i in 0..pts.len() {
-        tree.insert(rtree_rs::Rect::new(pts[i], pts[i]), i);
-    }
-
-    for i in 0..search_points.len() {
-        let mut count = 0;
-        let target = rtree_rs::Rect::new(search_points[i], search_points[i]);
-        while let Some(_) = tree.nearby(|rect, _| rect.box_dist(&target)).next() {
-            count += 1;
-            if count == k {
-                break;
-            }
-        }
-        assert_eq!(count, k);
-    }
-}
-
-// Rstar supports max 9 dimensions by default
-fn bench_rstar(pts: &Vec<[f64; 9]>, search_points: &Vec<[f64; 9]>, k: usize) {
-    let mut tree = rstar::RTree::new();
-    for i in 0..pts.len() {
-        tree.insert(pts[i]);
-    }
-
-    for i in 0..search_points.len() {
-        let mut count = 0;
-        while let Some(_) = tree.nearest_neighbor_iter(&search_points[i]).next() {
-            count += 1;
-            if count == k {
-                break;
-            }
-        }
-        assert_eq!(count, k);
-    }
-}
-
-fn bench_srtree<const D: usize>(
-    dimension: usize,
-    pts: &Vec<[f64; D]>,
-    search_points: &Vec<[f64; D]>,
-    k: usize,
-) {
-    let max_elements = 21;
-    let min_elements = 10;
-    let reinsert_count = min_elements;
-    let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
-    let mut tree = SRTree::new(dimension, params);
-    for point in pts {
-        tree.insert(point);
-    }
-
-    for point in search_points {
-        tree.query(point, k);
-    }
-}
-
-fn benchmark_with_uniform_dataset(criterion: &mut Criterion) {
-    const N: usize = 10_000; // # of training points
-    const D: usize = 9; // dimension of each point
-    const M: usize = 100; // # of search points
-    const K: usize = 100; // # of nearest neighbors to search
-
-    println!();
-    println!("Number of training points:   {:?}", N);
-    println!("Dimension of each point:     {:?}", D);
-    println!("Number of query points:      {:?}", M);
-    println!("Number of nearest neighbors: {:?}", K);
-
+fn generate_points<const D: usize>(n: usize, seed: [u8; 32]) -> Vec<[f64; D]> {
+    let mut rng = StdRng::from_seed(seed);
     let mut pts = Vec::new();
-    for _ in 0..N {
+    for _ in 0..n {
         let mut point = [0.; D];
         for item in point.iter_mut().take(D) {
-            *item = rand::random::<f64>() * 1_000_000.;
+            *item = rng.gen::<f64>() * 1_000_000.;
         }
         pts.push(point);
     }
+    pts
+}
 
-    let mut search_points = Vec::new();
-    for _ in 0..M {
-        let mut point = [0.; D];
-        for item in point.iter_mut().take(D) {
-            *item = rand::random::<f64>() * 1_000_000.;
-        }
-        search_points.push(point);
-    }
+fn insert(criterion: &mut Criterion) {
+    const N: usize = 10_000; // # of training points
+    const D: usize = 10; // dimension of each point
+    let pts: Vec<[f64; D]> = generate_points(N, INPUT_SEED);
 
-    criterion.bench_function("exhaustive search", |bencher| {
+    criterion.bench_function("insert", |bencher| {
         bencher.iter(|| {
-            bench_exhaustive(&pts, &search_points, K);
-        });
-    });
+            let max_elements = 21;
+            let min_elements = 7;
+            let reinsert_count = min_elements;
+            let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
+            let mut tree = SRTree::new(D, params);
 
-    criterion.bench_function("rtree", |bencher| {
-        bencher.iter(|| {
-            bench_rtree(&pts, &search_points, K);
-        });
-    });
-
-    criterion.bench_function("rstar", |bencher| {
-        bencher.iter(|| {
-            bench_rstar(&pts, &search_points, K);
-        });
-    });
-
-    criterion.bench_function("srtree", |bencher| {
-        bencher.iter(|| {
-            bench_srtree(D, &pts, &search_points, K);
+            for point in &pts {
+                tree.insert(point);
+            }
         });
     });
 }
 
-fn benchmark_with_cluster_dataset(criterion: &mut Criterion) {
-    const N: usize = 1000; // # of clusters
-    const W: usize = 1000; // # of points in a cluster
-    const D: usize = 100; // dimension of each point
+fn query(criterion: &mut Criterion) {
+    const N: usize = 10_000; // # of training points
+    const D: usize = 10; // dimension of each point
+    let pts: Vec<[f64; D]> = generate_points(N, INPUT_SEED);
+
+    let max_elements = 21;
+    let min_elements = 7;
+    let reinsert_count = min_elements;
+    let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
+    let mut tree = SRTree::new(D, params);
+    for point in &pts {
+        tree.insert(point);
+    }
+
     const M: usize = 100; // # of search points
     const K: usize = 100; // # of nearest neighbors to search
+    let query_pts: Vec<[f64; D]> = generate_points(M, QUERY_SEED);
 
-    println!();
-    println!("Number of clusters:   {:?}", N);
-    println!("Number of points per cluster:   {:?}", W);
-    println!("Dimension of each point:     {:?}", D);
-    println!("Number of query points:      {:?}", M);
-    println!("Number of nearest neighbors: {:?}", K);
-
-    let mut pts = Vec::new();
-    let mut start = 0.;
-    for _ in 0..N {
-        for _ in 0..W {
-            let mut point = [0.; D];
-            for item in point.iter_mut().take(D) {
-                *item = start + rand::random::<f64>() * 8000.;
+    criterion.bench_function("query", |bencher| {
+        bencher.iter(|| {
+            for point in &query_pts {
+                tree.query(point, K);
             }
-            pts.push(point);
-        }
-        start += 10_000.;
-    }
-
-    let mut search_points = Vec::new();
-    for _ in 0..M {
-        let mut point = [0.; D];
-        for item in point.iter_mut().take(D) {
-            *item = rand::random::<f64>() * 1_000_000.;
-        }
-        search_points.push(point);
-    }
-
-    criterion.bench_function("exhaustive search", |bencher| {
-        bencher.iter(|| {
-            bench_exhaustive(&pts, &search_points, K);
-        });
-    });
-
-    criterion.bench_function("rtree", |bencher| {
-        bencher.iter(|| {
-            bench_rtree(&pts, &search_points, K);
-        });
-    });
-
-    criterion.bench_function("srtree", |bencher| {
-        bencher.iter(|| {
-            bench_srtree(D, &pts, &search_points, K);
         });
     });
 }
 
-criterion_group!{
-    name = benches;
-    config = Criterion::default().measurement_time(Duration::from_secs(100));
-    targets = benchmark_with_uniform_dataset
-}
+criterion_group!(benches, insert, query);
 criterion_main!(benches);

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::{rngs::StdRng, SeedableRng, Rng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use srtree::{Params, SRTree};
 
 const INPUT_SEED: [u8; 32] = *b"PiH6Xi3GBBXhTK6UsXJYngHaF3fx4aYS";
@@ -40,26 +40,66 @@ fn insert(criterion: &mut Criterion) {
 
 fn query(criterion: &mut Criterion) {
     const N: usize = 10_000; // # of training points
-    const D: usize = 10; // dimension of each point
+    const D: usize = 9; // dimension of each point
+    const M: usize = 100; // # of search points
+    const K: usize = 100; // # of nearest neighbors to search
     let pts: Vec<[f64; D]> = generate_points(N, INPUT_SEED);
+    let query_pts: Vec<[f64; D]> = generate_points(M, QUERY_SEED);
+
+    let mut rtree = rtree_rs::RTree::new();
+    for i in 0..N {
+        rtree.insert(rtree_rs::Rect::new(pts[i], pts[i]), i);
+    }
+
+    let mut rstar = rstar::RTree::new();
+    for point in pts.clone() {
+        rstar.insert(point);
+    }
 
     let max_elements = 21;
     let min_elements = 7;
     let reinsert_count = min_elements;
     let params = Params::new(min_elements, max_elements, reinsert_count, true).unwrap();
-    let mut tree = SRTree::new(D, params);
+    let mut srtree = SRTree::new(D, params);
     for point in &pts {
-        tree.insert(point);
+        srtree.insert(point);
     }
 
-    const M: usize = 100; // # of search points
-    const K: usize = 100; // # of nearest neighbors to search
-    let query_pts: Vec<[f64; D]> = generate_points(M, QUERY_SEED);
+    let mut group = criterion.benchmark_group("query");
 
-    criterion.bench_function("query", |bencher| {
+    group.bench_function("rtree", |bencher| {
+        bencher.iter(|| {
+            for i in 0..M {
+                let mut count = 0;
+                let target = rtree_rs::Rect::new(query_pts[i], query_pts[i]);
+                while let Some(_) = rtree.nearby(|rect, _| rect.box_dist(&target)).next() {
+                    count += 1;
+                    if count == K {
+                        break;
+                    }
+                }
+            }
+        });
+    });
+
+    group.bench_function("rstar", |bencher| {
+        bencher.iter(|| {
+            for i in 0..M {
+                let mut count = 0;
+                while let Some(_) = rstar.nearest_neighbor_iter(&query_pts[i]).next() {
+                    count += 1;
+                    if count == K {
+                        break;
+                    }
+                }
+            }
+        });
+    });
+
+    group.bench_function("srtree", |bencher| {
         bencher.iter(|| {
             for point in &query_pts {
-                tree.query(point, K);
+                srtree.query(point, K);
             }
         });
     });

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -67,38 +67,41 @@ fn query(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("query");
 
-    group.bench_function("rtree", |bencher| {
-        bencher.iter(|| {
-            for i in 0..M {
-                let mut count = 0;
-                let target = rtree_rs::Rect::new(query_pts[i], query_pts[i]);
-                while let Some(_) = rtree.nearby(|rect, _| rect.box_dist(&target)).next() {
-                    count += 1;
-                    if count == K {
-                        break;
+    group
+        .bench_function("rtree", |bencher| {
+            bencher.iter(|| {
+                for i in 0..M {
+                    let mut count = 0;
+                    let target = rtree_rs::Rect::new(query_pts[i], query_pts[i]);
+                    while let Some(_) = rtree.nearby(|rect, _| rect.box_dist(&target)).next() {
+                        count += 1;
+                        if count == K {
+                            break;
+                        }
                     }
                 }
-            }
-        });
-    }).bench_function("rstar", |bencher| {
-        bencher.iter(|| {
-            for i in 0..M {
-                let mut count = 0;
-                while let Some(_) = rstar.nearest_neighbor_iter(&query_pts[i]).next() {
-                    count += 1;
-                    if count == K {
-                        break;
+            });
+        })
+        .bench_function("rstar", |bencher| {
+            bencher.iter(|| {
+                for i in 0..M {
+                    let mut count = 0;
+                    while let Some(_) = rstar.nearest_neighbor_iter(&query_pts[i]).next() {
+                        count += 1;
+                        if count == K {
+                            break;
+                        }
                     }
                 }
-            }
+            });
+        })
+        .bench_function("srtree", |bencher| {
+            bencher.iter(|| {
+                for point in &query_pts {
+                    srtree.query(point, K);
+                }
+            });
         });
-    }).bench_function("srtree", |bencher| {
-        bencher.iter(|| {
-            for point in &query_pts {
-                srtree.query(point, K);
-            }
-        });
-    });
 }
 
 criterion_group!(benches, insert, query);

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -3,7 +3,5 @@ name = "demo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 srtree = { path = "../srtree" }

--- a/srtree/Cargo.toml
+++ b/srtree/Cargo.toml
@@ -3,8 +3,6 @@ name = "srtree"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ordered-float = "3.4.0"
 


### PR DESCRIPTION
This PR adds performance benchmarks (at dimension = 9) with [RStar](https://github.com/georust/rstar) and [RTree](https://github.com/tidwall/rtree.rs) using [criterion](https://docs.rs/criterion/latest/criterion/).

Results for a small uniform dataset (10K points):
```
Benchmarking query/rtree: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 60.4s, or reduce sample count to 10.
query/rtree             time:   [602.24 ms 602.85 ms 603.46 ms]                        
                        change: [+0.7733% +1.0330% +1.2743%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking query/rstar: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 60.2s, or reduce sample count to 10.
query/rstar             time:   [602.90 ms 603.84 ms 604.83 ms]                        
                        change: [-1.1622% -0.8871% -0.6227%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Benchmarking query/ball-tree: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.6s, or reduce sample count to 80.
query/ball-tree         time:   [56.457 ms 56.913 ms 57.480 ms]                            
                        change: [+10.422% +11.315% +12.372%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking query/srtree: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 28.5s, or reduce sample count to 10.
query/srtree            time:   [270.79 ms 272.52 ms 274.30 ms]                         
                        change: [+2.7786% +3.3846% +4.0669%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
Results for a big dataset (9 dimensional 1 millions points):
```
Benchmarking query/ball-tree: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 916.2s, or reduce sample count to 10.
query/ball-tree         time:   [9.1886 s 9.2039 s 9.2203 s]                               
                        change: [+17736% +17793% +17844%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking query/srtree: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 270.5s, or reduce sample count to 10.
query/srtree            time:   [2.8088 s 2.8319 s 2.8557 s]                            
                        change: [+979.53% +987.69% +996.56%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  11 (11.00%) high mild
Benchmarking query/exhaustive: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 434.8s, or reduce sample count to 10.
query/exhaustive        time:   [4.2808 s 4.2855 s 4.2907 s]                                
                        change: [+9719.6% +9742.6% +9764.4%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```