### PR TITLE
Indexing of data points

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,6 +12,7 @@ petal-neighbors = "0.8.0"
 ndarray = "0.15"
 ordered-float = "3.4.0"
 criterion = "0.3"
+rand_chacha = "0.3.1"
 
 [[bench]]
 name = "srtree"

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -52,7 +52,7 @@ Link to the dataset: https://simplemaps.com/data/world-cities.
 
 This function doesn't modify the dataset but only uses locations (latitude & longitude) for benchmarking purposes.
 */
-fn world_cities_dataset() -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
+fn world_cities_dataset(m: usize) -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
     let mut pts = Vec::new();
     let mut query_pts: Vec<[f64; 2]> = Vec::new();
     let file = File::open("worldcities.csv");
@@ -87,7 +87,7 @@ fn world_cities_dataset() -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
     }
 
     pts.shuffle(&mut ChaChaRng::from_seed(QUERY_SEED));
-    for i in 0..100 {
+    for i in 0..m.min(pts.len()) {
         query_pts.push(pts[i].clone());
     }
     (pts, query_pts)
@@ -102,7 +102,7 @@ fn query(criterion: &mut Criterion) {
     //let (pts, query_pts): (Vec<[f64; D]>, Vec<[f64; D]>) = uniform_dataset(N, M);
 
     const D: usize = 2; // dimension of each point
-    let (pts, query_pts) = world_cities_dataset();
+    let (pts, query_pts) = world_cities_dataset(M);
 
     let mut group = criterion.benchmark_group("query");
 

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -68,7 +68,7 @@ fn world_cities_dataset() -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
             continue;
         }
         if line.is_ok() {
-            let mut location = [0., 0.];
+            let mut location = [f64::INFINITY, f64::INFINITY];
             let line = line.as_ref().unwrap();
             for (i, val) in line.split(",").enumerate() {
                 let mut chars = val.chars();
@@ -77,12 +77,12 @@ fn world_cities_dataset() -> (Vec<[f64; 2]>, Vec<[f64; 2]>) {
                 let val = chars.as_str();
                 if i == 2 || i == 3 {
                     let c: f64 = val.parse().unwrap_or(f64::INFINITY);
-                    if c != f64::INFINITY {
-                        location[i - 2] = c;
-                    }
+                    location[i - 2] = c;
                 }
             }
-            pts.push(location);
+            if location[0] != f64::INFINITY && location[1] != f64::INFINITY {
+                pts.push(location);
+            }
         }
     }
 

--- a/bench/benches/srtree.rs
+++ b/bench/benches/srtree.rs
@@ -98,8 +98,8 @@ fn query(criterion: &mut Criterion) {
     const M: usize = 100; // # of search points
     const K: usize = 100; // # of nearest neighbors to search
 
-    // const D: usize = 9; // dimension of each point
-    // let (pts, query_pts): (Vec<[f64; D]>, Vec<[f64; D]>) = uniform_dataset(N, M);
+    //const D: usize = 9; // dimension of each point
+    //let (pts, query_pts): (Vec<[f64; D]>, Vec<[f64; D]>) = uniform_dataset(N, M);
 
     const D: usize = 2; // dimension of each point
     let (pts, query_pts) = world_cities_dataset();

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -3,15 +3,12 @@ use srtree::{Params, SRTree};
 fn main() {
     let params = Params::new(7, 15, 7, true).unwrap();
     let mut tree: SRTree<f64> = SRTree::new(2, params);
-    let number_of_points = 100;
+    tree.insert(&vec![0., 0.], 0);
+    tree.insert(&vec![1., 1.], 1);
+    tree.insert(&vec![2., 2.], 2);
+    tree.insert(&vec![3., 3.], 3);
+    tree.insert(&vec![4., 4.], 4);
 
-    for i in 0..number_of_points {
-        let x = f64::from(i);
-        let y = f64::from(i);
-        tree.insert(&[x, y]);
-    }
-
-    let neighbors = tree.query(&[0., 0.], 2);
-    println!("{:?}", neighbors[0]); // [0., 0.]
-    println!("{:?}", neighbors[1]); // [1., 1.]
+    let neighbors = tree.query(&[8., 8.], 3);
+    println!("{neighbors:?}"); // [4, 3, 2] (sorted by distance)
 }

--- a/srtree/src/algorithm/choose_subtree.rs
+++ b/srtree/src/algorithm/choose_subtree.rs
@@ -41,6 +41,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::point::Point;
+
     use super::*;
 
     #[test]
@@ -55,7 +57,7 @@ mod tests {
         }
 
         let expected_index = 9;
-        let search_node = Node::new_point(&vec![100., 0.]);
+        let search_node = Node::new_point(&Point::with_coords(vec![100., 0.]));
         let selected_index = choose_closest_node_index(&node, &search_node);
         assert_eq!(selected_index, expected_index);
     }

--- a/srtree/src/algorithm/query.rs
+++ b/srtree/src/algorithm/query.rs
@@ -62,17 +62,17 @@ where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
     let mut result = Vec::new();
-    let mut distance_heap = BinaryHeap::new();
-    search(node, point, k, &mut distance_heap);
-    while !distance_heap.is_empty() {
-        let last = distance_heap.pop().unwrap();
+    let mut neighbors = BinaryHeap::new();
+    search(node, point, k, &mut neighbors);
+    while !neighbors.is_empty() {
+        let last = neighbors.pop().unwrap();
         result.push(last.point);
     }
     result.reverse();
     result
 }
 
-fn search<T>(node: &Node<T>, point: &[T], k: usize, distance_heap: &mut BinaryHeap<Neighbor<T>>)
+fn search<T>(node: &Node<T>, point: &[T], k: usize, neighbors: &mut BinaryHeap<Neighbor<T>>)
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
@@ -80,16 +80,16 @@ where
         // insert all potential neighbors (with their distances) in a leaf node:
         node.points().iter().for_each(|candidate| {
             let neighbor_distance = euclidean_squared(candidate, point);
-            distance_heap.push(Neighbor::new(
+            neighbors.push(Neighbor::new(
                 OrderedFloat(neighbor_distance),
                 candidate.clone(),
             ));
-        });
 
-        // keep only closest k distances:
-        while distance_heap.len() > k {
-            distance_heap.pop();
-        }
+            // keep only closest k neighbors:
+            if neighbors.len() > k {
+                neighbors.pop();
+            }
+        });
     } else {
         let mut to_visit = Vec::new();
         for (child_index, child) in node.nodes().iter().enumerate() {
@@ -101,8 +101,8 @@ where
         for (child_distance, child_index) in to_visit {
             // if k neighbors were already sampled, then the target distance is kth closest distance:
             let mut target_distance = OrderedFloat(T::infinity());
-            if distance_heap.len() == k {
-                target_distance = distance_heap.peek().unwrap().distance;
+            if neighbors.len() == k {
+                target_distance = neighbors.peek().unwrap().distance;
             }
 
             // search pruning: don't visit nodes with min_distance bigger than kth distance
@@ -110,7 +110,7 @@ where
                 break;
             }
 
-            search(&node.nodes()[child_index], point, k, distance_heap);
+            search(&node.nodes()[child_index], point, k, neighbors);
         }
     }
 }

--- a/srtree/src/algorithm/split.rs
+++ b/srtree/src/algorithm/split.rs
@@ -83,7 +83,8 @@ where
 
     // 2. Sort node points along that axis
     if node.is_leaf() {
-        node.points_mut().sort_by_key(|p| OrderedFloat(p[axis]));
+        node.points_mut()
+            .sort_by_key(|p| OrderedFloat(p.coords[axis]));
     } else {
         node.nodes_mut()
             .sort_by_key(|child| OrderedFloat(child.get_sphere().center[axis]));
@@ -125,6 +126,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::point::Point;
+
     use super::*;
 
     pub fn get_test_points() -> Vec<Vec<f64>> {
@@ -141,8 +144,9 @@ mod tests {
     pub fn test_choose_split_axis() {
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, 5);
-        get_test_points().iter().for_each(|point| {
-            node.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            node.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
         });
 
         let expected_axis = 1;
@@ -154,8 +158,9 @@ mod tests {
     pub fn test_choose_split_index() {
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, 5);
-        get_test_points().iter().for_each(|point| {
-            node.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            node.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
         });
 
         let params = Params::new(1, 3, 1, true).unwrap();
@@ -170,8 +175,9 @@ mod tests {
 
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, params.max_number_of_elements);
-        get_test_points().iter().for_each(|point| {
-            node.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            node.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
         });
 
         let sibling = split(&mut node, &origin, &params);
@@ -185,9 +191,10 @@ mod tests {
 
         let origin = vec![0., 0.];
         let mut node = Node::new_node(&origin, params.max_number_of_elements, 1);
-        get_test_points().iter().for_each(|point| {
-            let mut leaf = Node::new_leaf(point, params.max_number_of_elements);
-            leaf.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            let mut leaf = Node::new_leaf(point_coords, params.max_number_of_elements);
+            leaf.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
             reshape(&mut leaf);
             node.nodes_mut().push(leaf);
         });
@@ -204,12 +211,12 @@ mod tests {
 
         let origin = vec![0., 10.];
         let mut node = Node::new_leaf(&origin, params.max_number_of_elements);
-        node.points_mut().push(vec![0., 9.]);
-        node.points_mut().push(vec![0., 8.]);
-        node.points_mut().push(vec![0., 7.]);
-        node.points_mut().push(vec![0., 6.]);
-        node.points_mut().push(vec![0., 1.]);
-        node.points_mut().push(vec![0., 2.]);
+        node.points_mut().push(Point::with_coords(vec![0., 9.]));
+        node.points_mut().push(Point::with_coords(vec![0., 8.]));
+        node.points_mut().push(Point::with_coords(vec![0., 7.]));
+        node.points_mut().push(Point::with_coords(vec![0., 6.]));
+        node.points_mut().push(Point::with_coords(vec![0., 1.]));
+        node.points_mut().push(Point::with_coords(vec![0., 2.]));
         reshape(&mut node);
 
         let sibling = split(&mut node, &origin, &params);

--- a/srtree/src/algorithm/split.rs
+++ b/srtree/src/algorithm/split.rs
@@ -9,7 +9,7 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-fn choose_split_axis<T>(node: &Node<T>) -> usize
+fn choose_split_axis<T>(node: &mut Node<T>) -> usize
 where
     T: Debug + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
@@ -23,6 +23,8 @@ where
             selected_index = i;
         }
     }
+
+    node.set_variance(variance);
     selected_index
 }
 
@@ -136,30 +138,6 @@ mod tests {
     }
 
     #[test]
-    pub fn test_node_mean_variance_calculation() {
-        let max_number_of_elements = 5;
-        let origin = vec![0., 0.];
-        let mut node = Node::new_node(&origin, max_number_of_elements, 1);
-
-        let mut leaf1 = Node::new_leaf(&origin, max_number_of_elements);
-        leaf1.points_mut().push(vec![0., 0.]);
-        leaf1.points_mut().push(vec![0., 1.]);
-        reshape(&mut leaf1);
-
-        node.nodes_mut().push(leaf1);
-
-        let mut leaf2 = Node::new_leaf(&origin, max_number_of_elements);
-        leaf2.points_mut().push(vec![0., 100.]);
-        leaf2.points_mut().push(vec![0., 200.]);
-        reshape(&mut leaf2);
-
-        node.nodes_mut().push(leaf2);
-        reshape(&mut node);
-
-        assert_eq!(node.get_variance()[1], 6837.6875);
-    }
-
-    #[test]
     pub fn test_choose_split_axis() {
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, 5);
@@ -168,7 +146,7 @@ mod tests {
         });
 
         let expected_axis = 1;
-        let selected_axis = choose_split_axis(&node);
+        let selected_axis = choose_split_axis(&mut node);
         assert_eq!(expected_axis, selected_axis);
     }
 

--- a/srtree/src/measure/mean.rs
+++ b/srtree/src/measure/mean.rs
@@ -27,13 +27,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::point::Point;
+
     use super::*;
 
     #[test]
     pub fn test_leaf_mean_calculation() {
         let mut leaf = Node::new_leaf(&vec![0., 0.], 5);
-        leaf.points_mut().push(vec![1., 0.]);
-        leaf.points_mut().push(vec![0., 1.]);
+        leaf.points_mut().push(Point::with_coords(vec![1., 0.]));
+        leaf.points_mut().push(Point::with_coords(vec![0., 1.]));
         let mean = calculate(&leaf, 0, leaf.immed_children());
         assert_eq!(mean, vec![0.5, 0.5]);
     }
@@ -41,12 +43,12 @@ mod tests {
     #[test]
     pub fn test_node_mean_calculation() {
         let mut leaf1 = Node::new_leaf(&vec![0., 1.], 5);
-        leaf1.points_mut().push(vec![0., 0.]);
-        leaf1.points_mut().push(vec![0., 1.]);
-        leaf1.points_mut().push(vec![0., 2.]);
+        leaf1.points_mut().push(Point::with_coords(vec![0., 0.]));
+        leaf1.points_mut().push(Point::with_coords(vec![0., 1.]));
+        leaf1.points_mut().push(Point::with_coords(vec![0., 2.]));
         let mut leaf2 = Node::new_leaf(&vec![0., 4.], 5);
-        leaf2.points_mut().push(vec![0., 3.]);
-        leaf2.points_mut().push(vec![0., 5.]);
+        leaf2.points_mut().push(Point::with_coords(vec![0., 3.]));
+        leaf2.points_mut().push(Point::with_coords(vec![0., 5.]));
 
         let mut node = Node::new_node(&vec![0., 0.], 5, 1);
         node.nodes_mut().push(leaf1);

--- a/srtree/src/measure/variance.rs
+++ b/srtree/src/measure/variance.rs
@@ -42,6 +42,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::point::Point;
+
     use super::*;
 
     pub fn get_test_points() -> Vec<Vec<f64>> {
@@ -58,8 +60,9 @@ mod tests {
     pub fn test_variance_calculation() {
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, 5);
-        get_test_points().iter().for_each(|point| {
-            node.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            node.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
         });
 
         let variance = calculate(&node, 0, node.immed_children());
@@ -71,8 +74,9 @@ mod tests {
     pub fn test_range_variance_calculation() {
         let origin = vec![0., 0.];
         let mut node = Node::new_leaf(&origin, 5);
-        get_test_points().iter().for_each(|point| {
-            node.points_mut().push(point.to_owned());
+        get_test_points().iter().for_each(|point_coords| {
+            node.points_mut()
+                .push(Point::with_coords(point_coords.to_owned()));
         });
 
         let variance = calculate(&node, 0, 2);

--- a/srtree/src/shape/mod.rs
+++ b/srtree/src/shape/mod.rs
@@ -1,3 +1,4 @@
+pub mod point;
 pub mod rect;
 pub mod reshape;
 pub mod sphere;

--- a/srtree/src/shape/point.rs
+++ b/srtree/src/shape/point.rs
@@ -1,30 +1,24 @@
+use ordered_float::Float;
 use std::{
     fmt::Debug,
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use ordered_float::Float;
-
-use crate::measure::distance::{euclidean, euclidean_squared};
-
-pub struct Point<T, D> {
+pub struct Point<T> {
     pub coords: Vec<T>,
-    pub data: D,
+    pub index: usize,
 }
 
-impl <T, D> Point<T, D>
+impl<T> Point<T>
 where
     T: Debug + Copy + Float + AddAssign + SubAssign + MulAssign + DivAssign,
 {
-    pub fn new(coords: Vec<T>, data: D) -> Point<T, D> {
-        Point { coords, data }
+    pub fn new(coords: Vec<T>, index: usize) -> Point<T> {
+        Point { coords, index }
     }
 
-    pub fn distance(&self, point: &Point<T, D>) -> T {
-        euclidean(&self.coords, &point.coords)
-    }
-
-    pub fn distance_squared(&self, point: &Point<T, D>) -> T {
-        euclidean_squared(&self.coords, &point.coords)
+    #[allow(dead_code)]
+    pub fn with_coords(coords: Vec<T>) -> Point<T> {
+        Point { coords, index: 0 }
     }
 }

--- a/srtree/src/shape/point.rs
+++ b/srtree/src/shape/point.rs
@@ -1,0 +1,30 @@
+use std::{
+    fmt::Debug,
+    ops::{AddAssign, DivAssign, MulAssign, SubAssign},
+};
+
+use ordered_float::Float;
+
+use crate::measure::distance::{euclidean, euclidean_squared};
+
+pub struct Point<T, D> {
+    pub coords: Vec<T>,
+    pub data: D,
+}
+
+impl <T, D> Point<T, D>
+where
+    T: Debug + Copy + Float + AddAssign + SubAssign + MulAssign + DivAssign,
+{
+    pub fn new(coords: Vec<T>, data: D) -> Point<T, D> {
+        Point { coords, data }
+    }
+
+    pub fn distance(&self, point: &Point<T, D>) -> T {
+        euclidean(&self.coords, &point.coords)
+    }
+
+    pub fn distance_squared(&self, point: &Point<T, D>) -> T {
+        euclidean_squared(&self.coords, &point.coords)
+    }
+}

--- a/srtree/src/shape/reshape.rs
+++ b/srtree/src/shape/reshape.rs
@@ -1,6 +1,5 @@
 use crate::measure::distance::euclidean;
 use crate::measure::mean;
-use crate::measure::variance;
 use crate::node::Node;
 use ordered_float::Float;
 use std::{
@@ -51,9 +50,6 @@ where
 
     let radius = ds.min(dr);
     node.set_sphere(Sphere::new(centroid, radius));
-
-    let variance = variance::calculate(node, 0, node.immed_children());
-    node.set_variance(variance);
 
     node.set_total_children(total_children);
 }

--- a/srtree/src/shape/reshape.rs
+++ b/srtree/src/shape/reshape.rs
@@ -23,10 +23,10 @@ where
     if node.is_leaf() {
         node.points().iter().for_each(|point| {
             for i in 0..node.dimension() {
-                low[i] = low[i].min(point[i]);
-                high[i] = high[i].max(point[i]);
+                low[i] = low[i].min(point.coords[i]);
+                high[i] = high[i].max(point.coords[i]);
             }
-            ds = ds.max(euclidean(&centroid, point));
+            ds = ds.max(euclidean(&centroid, &point.coords));
             dr = ds;
         });
         total_children = node.points().len();
@@ -56,6 +56,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::shape::point::Point;
+
     use super::*;
 
     #[test]
@@ -63,7 +65,8 @@ mod tests {
         let origin = vec![0., 0.];
         let mut leaf = Node::new_leaf(&origin, 5);
         for i in 0..5 {
-            leaf.points_mut().push(vec![0., i as f64]);
+            leaf.points_mut()
+                .push(Point::with_coords(vec![0., i as f64]));
         }
         reshape(&mut leaf);
 
@@ -84,10 +87,10 @@ mod tests {
     pub fn test_reshape_leaf_node_radius() {
         let origin = vec![0., 0.];
         let mut leaf = Node::new_leaf(&origin, 5);
-        leaf.points_mut().push(vec![100., 100.]);
-        leaf.points_mut().push(vec![100., 150.]);
-        leaf.points_mut().push(vec![250., 250.]);
-        leaf.points_mut().push(vec![150., 300.]);
+        leaf.points_mut().push(Point::with_coords(vec![100., 100.]));
+        leaf.points_mut().push(Point::with_coords(vec![100., 150.]));
+        leaf.points_mut().push(Point::with_coords(vec![250., 250.]));
+        leaf.points_mut().push(Point::with_coords(vec![150., 300.]));
         reshape(&mut leaf);
         assert_eq!(leaf.get_sphere().radius, 111.80339887498948);
     }

--- a/srtree/src/srtree.rs
+++ b/srtree/src/srtree.rs
@@ -3,6 +3,7 @@ use crate::algorithm::query::nearest_neighbors;
 use crate::algorithm::split::split;
 use crate::node::Node;
 use crate::params::Params;
+use crate::shape::point::Point;
 use ordered_float::Float;
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
@@ -31,17 +32,20 @@ where
         }
     }
 
-    pub fn insert(&mut self, point: &[T]) -> InsertionResult {
-        if self.dimension != point.len() {
+    pub fn insert(&mut self, point_coords: &Vec<T>, index: usize) -> InsertionResult {
+        if self.dimension != point_coords.len() {
             eprintln!("Problem inserting a point: different dimensions");
             return InsertionResult::Failure;
         }
         if self.root.is_none() {
-            self.root = Some(Node::new_leaf(point, self.params.max_number_of_elements));
+            self.root = Some(Node::new_leaf(
+                point_coords,
+                self.params.max_number_of_elements,
+            ));
         }
 
         if let Some(root) = self.root.as_mut() {
-            insert_data(root, point, &self.params);
+            insert_data(root, &Point::new(point_coords.clone(), index), &self.params);
 
             if root.immed_children() > self.params.max_number_of_elements {
                 let sibling = split(root, &root.get_sphere().center.clone(), &self.params);
@@ -60,7 +64,7 @@ where
         InsertionResult::Success
     }
 
-    pub fn query(&mut self, point: &[T], k: usize) -> Vec<Vec<T>> {
+    pub fn query(&mut self, point: &[T], k: usize) -> Vec<usize> {
         if let Some(root) = self.root.as_mut() {
             nearest_neighbors(root, point, k)
         } else {
@@ -78,8 +82,8 @@ mod tests {
         let params = Params::new(3, 7, 3, true).unwrap();
         let mut tree: SRTree<f64> = SRTree::new(2, params);
         let search_point = vec![1.0, 0.0];
-        assert!(!tree.query(&search_point, 1).contains(&search_point)); // not inserted yet
-        tree.insert(&vec![1.0, 0.0]);
-        assert!(tree.query(&search_point, 1).contains(&search_point)); // inserted
+        assert!(!tree.query(&search_point, 1).contains(&0)); // not inserted yet
+        tree.insert(&search_point, 0);
+        assert!(tree.query(&search_point, 1).contains(&0)); // inserted
     }
 }

--- a/srtree/tests/test_insertion.rs
+++ b/srtree/tests/test_insertion.rs
@@ -5,9 +5,9 @@ pub fn test_insertion_invalid_dimensions() {
     let params = Params::new(3, 7, 3, true).unwrap();
     let mut tree = SRTree::new(2, params);
 
-    let result = tree.insert(&[0., 1.]); // valid insertion
+    let result = tree.insert(&vec![0., 1.], 0); // valid insertion
     assert!(matches!(result, InsertionResult::Success));
 
-    let result = tree.insert(&[0., 1., 2.]); // now 3D insertion should fail
+    let result = tree.insert(&vec![0., 1., 2.], 1); // now 3D insertion should fail
     assert!(matches!(result, InsertionResult::Failure));
 }

--- a/srtree/tests/test_query.rs
+++ b/srtree/tests/test_query.rs
@@ -25,26 +25,26 @@ fn test_with_random_points() {
     let mut rng = rand::thread_rng();
 
     let mut all_points = Vec::new();
-    for _ in 0..number_of_points {
-        let mut point = Vec::new();
+    for i in 0..number_of_points {
+        let mut point_coords = Vec::new();
         for _ in 0..number_of_dimensions {
             let x: f64 = 1000000. * rng.gen::<f64>();
-            point.push(x);
+            point_coords.push(x);
         }
-        tree.insert(&point);
-        all_points.push(point);
+        tree.insert(&point_coords, i);
+        all_points.push((point_coords, i));
     }
 
     let mut points = all_points.clone();
     for p in all_points.iter() {
         // SRTree nearest neighbors
-        let result = tree.query(&p, k);
+        let result = tree.query(&p.0, k);
 
         // Brute-force
-        points.sort_by_key(|a| OrderedFloat(euclidean_squared(a, p)));
+        points.sort_by_key(|a| OrderedFloat(euclidean_squared(&a.0, &p.0)));
 
         for i in 0..k {
-            assert_eq!(result[i], points[i]);
+            assert_eq!(result[i], points[i].1);
         }
     }
 }


### PR DESCRIPTION
This PR adds "indexing" of points (see #14) to make it easier for clustering algorithms (e.g. DBSCAN / HDBSCAN) to use SRTree. Here, [`insert`](https://github.com/aicers/srtree/blob/5c489f5a2e05b8fa9af940482140f09353b9f8a5/srtree/src/srtree.rs#L35) takes two parameters: `point_coords ` and its `index`, the latter can be handled by SRTree later. 

Currently, converting an indexed point to [`Node`](https://github.com/aicers/srtree/blob/5c489f5a2e05b8fa9af940482140f09353b9f8a5/srtree/src/node.rs#L84) doesn't look clean: the node's [`total_children`](https://github.com/aicers/srtree/blob/5c489f5a2e05b8fa9af940482140f09353b9f8a5/srtree/src/node.rs#L90) attribute is being used to keep the point index. 
```
    pub fn new_point(point: &Point<T>) -> Node<T> {
        Node::new(
            Rect::from_point(&point.coords),
            Sphere::from_point(&point.coords),
            Data::Points(Vec::with_capacity(1)),
            vec![T::zero(); point.coords.len()],
            point.index,
            0,
        )
    }
```

Possible solution: convert all `Vec<T>` points to  struct [`Point`](https://github.com/aicers/srtree/blob/point/srtree/src/shape/point.rs)s. 